### PR TITLE
Remove Upload from Features menu

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -7,7 +7,6 @@ import {
   LayoutDashboard,
   FileText,
   FolderOpen,
-  Upload,
   Settings,
   FileCheck,
   Table2,
@@ -42,7 +41,6 @@ function SectionLabel({ children }: { children: string }) {
 const mainNavItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, countKey: "total_documents" as const },
   { href: "/templates", label: "Templates", icon: FolderOpen, countKey: "total_templates" as const },
-  { href: "/documents/upload", label: "Upload", icon: Upload, countKey: null },
   { href: "/insight-templates", label: "Insight Templates", icon: Lightbulb, countKey: null },
   { href: "/llm-logs", label: "LLM Logs", icon: Activity, countKey: null },
   { href: "/dependencies", label: "Dependencies", icon: Blocks, countKey: null },


### PR DESCRIPTION
## Summary
- Remove the Upload shortcut from the sidebar Features section
- Upload remains accessible from the Documents page inside IDP Space
- Clean up unused `Upload` icon import

## Test plan
- [ ] Verify Upload no longer appears in the Features section of the sidebar
- [ ] Verify Documents page still has the Upload Document button/link

🤖 Generated with [Claude Code](https://claude.com/claude-code)