### PR TITLE
Support multiple example files per template

### DIFF
--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from sqlalchemy.orm import Session
 from sqlalchemy import func
+from typing import Optional
 
 logger = logging.getLogger("idp.templates")
 
@@ -16,6 +17,31 @@ from app.core.file_utils import save_upload_file, validate_file_type, delete_fil
 from app.schemas.responses import SuccessResponse
 
 router = APIRouter(prefix="/api/templates", tags=["templates"])
+
+
+def _get_example_files(template: Template) -> list[str]:
+    """Parse the example_files JSON column into a list."""
+    if not template.example_files:
+        return []
+    try:
+        files = json.loads(template.example_files)
+        return files if isinstance(files, list) else [files]
+    except (ValueError, TypeError):
+        # Legacy single-path value
+        return [template.example_files]
+
+
+def _template_response(template: Template, doc_count: int) -> TemplateResponse:
+    return TemplateResponse(
+        id=template.id,
+        name=template.name,
+        description=template.description,
+        example_files=_get_example_files(template),
+        created_at=template.created_at,
+        updated_at=template.updated_at,
+        fields=[FieldResponse.model_validate(f) for f in template.fields],
+        document_count=doc_count or 0,
+    )
 
 
 @router.get("", response_model=list[TemplateListResponse])
@@ -45,26 +71,30 @@ def list_templates(db: Session = Depends(get_db)):
 async def create_template(
     name: str = Form(...),
     description: str = Form(None),
-    file: UploadFile | None = File(None),
+    files: list[UploadFile] = File(default=[]),
     db: Session = Depends(get_db),
 ):
     existing = db.query(Template).filter(Template.name == name).first()
     if existing:
         raise HTTPException(400, "Template with this name already exists")
 
-    example_file = None
-    if file and file.filename:
-        if not validate_file_type(file.filename):
-            raise HTTPException(400, "Unsupported file type")
-        example_file, _ = await save_upload_file(file)
+    saved_paths: list[str] = []
+    for f in files:
+        if f and f.filename:
+            if not validate_file_type(f.filename):
+                raise HTTPException(400, f"Unsupported file type: {f.filename}")
+            path, _ = await save_upload_file(f)
+            saved_paths.append(path)
 
-    template = Template(name=name, description=description, example_file=example_file)
+    example_files_json = json.dumps(saved_paths) if saved_paths else None
+
+    template = Template(name=name, description=description, example_files=example_files_json)
     db.add(template)
     db.commit()
     db.refresh(template)
 
-    # If file was uploaded, auto-suggest fields
-    if example_file:
+    # If files were uploaded, auto-suggest fields
+    if saved_paths:
         try:
             from app.services.pipeline import suggest_fields_for_template
             await suggest_fields_for_template(db, template)
@@ -73,12 +103,7 @@ async def create_template(
 
     db.refresh(template)
     doc_count = db.query(func.count(Document.id)).filter(Document.template_id == template.id).scalar()
-    return TemplateResponse(
-        id=template.id, name=template.name, description=template.description,
-        example_file=template.example_file, created_at=template.created_at,
-        updated_at=template.updated_at, fields=[FieldResponse.model_validate(f) for f in template.fields],
-        document_count=doc_count or 0,
-    )
+    return _template_response(template, doc_count)
 
 
 @router.get("/{template_id}", response_model=TemplateResponse)
@@ -87,12 +112,7 @@ def get_template(template_id: int, db: Session = Depends(get_db)):
     if not template:
         raise HTTPException(404, "Template not found")
     doc_count = db.query(func.count(Document.id)).filter(Document.template_id == template.id).scalar()
-    return TemplateResponse(
-        id=template.id, name=template.name, description=template.description,
-        example_file=template.example_file, created_at=template.created_at,
-        updated_at=template.updated_at, fields=[FieldResponse.model_validate(f) for f in template.fields],
-        document_count=doc_count or 0,
-    )
+    return _template_response(template, doc_count)
 
 
 @router.put("/{template_id}", response_model=TemplateResponse)
@@ -107,12 +127,7 @@ def update_template(template_id: int, data: TemplateUpdate, db: Session = Depend
     db.commit()
     db.refresh(template)
     doc_count = db.query(func.count(Document.id)).filter(Document.template_id == template.id).scalar()
-    return TemplateResponse(
-        id=template.id, name=template.name, description=template.description,
-        example_file=template.example_file, created_at=template.created_at,
-        updated_at=template.updated_at, fields=[FieldResponse.model_validate(f) for f in template.fields],
-        document_count=doc_count or 0,
-    )
+    return _template_response(template, doc_count)
 
 
 @router.delete("/{template_id}", response_model=SuccessResponse)
@@ -120,8 +135,8 @@ def delete_template(template_id: int, db: Session = Depends(get_db)):
     template = db.query(Template).filter(Template.id == template_id).first()
     if not template:
         raise HTTPException(404, "Template not found")
-    if template.example_file:
-        delete_file(template.example_file)
+    for path in _get_example_files(template):
+        delete_file(path)
     db.delete(template)
     db.commit()
     return SuccessResponse(message=f"Template '{template.name}' deleted")
@@ -132,8 +147,8 @@ async def suggest_fields(template_id: int, db: Session = Depends(get_db)):
     template = db.query(Template).filter(Template.id == template_id).first()
     if not template:
         raise HTTPException(404, "Template not found")
-    if not template.example_file:
-        raise HTTPException(400, "Template has no example file for field suggestion")
+    if not _get_example_files(template):
+        raise HTTPException(400, "Template has no example files for field suggestion")
     try:
         from app.services.pipeline import suggest_fields_for_template
         await suggest_fields_for_template(db, template)
@@ -141,6 +156,53 @@ async def suggest_fields(template_id: int, db: Session = Depends(get_db)):
         raise HTTPException(500, f"Field suggestion failed: {str(e)}")
     db.refresh(template)
     return [FieldResponse.model_validate(f) for f in template.fields]
+
+
+@router.post("/{template_id}/example-files", response_model=TemplateResponse)
+async def add_example_files(
+    template_id: int,
+    files: list[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+):
+    """Add additional example files to an existing template."""
+    template = db.query(Template).filter(Template.id == template_id).first()
+    if not template:
+        raise HTTPException(404, "Template not found")
+
+    current_files = _get_example_files(template)
+
+    for f in files:
+        if f and f.filename:
+            if not validate_file_type(f.filename):
+                raise HTTPException(400, f"Unsupported file type: {f.filename}")
+            path, _ = await save_upload_file(f)
+            current_files.append(path)
+
+    template.example_files = json.dumps(current_files)
+    db.commit()
+    db.refresh(template)
+    doc_count = db.query(func.count(Document.id)).filter(Document.template_id == template.id).scalar()
+    return _template_response(template, doc_count)
+
+
+@router.delete("/{template_id}/example-files/{file_index}", response_model=TemplateResponse)
+def remove_example_file(template_id: int, file_index: int, db: Session = Depends(get_db)):
+    """Remove an example file by its index."""
+    template = db.query(Template).filter(Template.id == template_id).first()
+    if not template:
+        raise HTTPException(404, "Template not found")
+
+    current_files = _get_example_files(template)
+    if file_index < 0 or file_index >= len(current_files):
+        raise HTTPException(400, "Invalid file index")
+
+    removed = current_files.pop(file_index)
+    delete_file(removed)
+    template.example_files = json.dumps(current_files) if current_files else None
+    db.commit()
+    db.refresh(template)
+    doc_count = db.query(func.count(Document.id)).filter(Document.template_id == template.id).scalar()
+    return _template_response(template, doc_count)
 
 
 # --- Field CRUD ---

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -12,7 +12,22 @@ class Template(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    example_file: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # JSON array of file paths, e.g. '["uploads/a.pdf","uploads/b.pdf"]'
+    example_files: Mapped[str | None] = mapped_column("example_files", Text, nullable=True)
+
+    # Legacy column kept for backward compat — reads are routed through example_files
+    @property
+    def example_file(self) -> str | None:
+        """Return the first example file for backward compatibility."""
+        import json as _json
+        if not self.example_files:
+            return None
+        try:
+            files = _json.loads(self.example_files)
+            return files[0] if files else None
+        except (ValueError, TypeError):
+            # Legacy single-path value
+            return self.example_files
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/backend/app/schemas/template.py
+++ b/backend/app/schemas/template.py
@@ -61,7 +61,7 @@ class TemplateResponse(BaseModel):
     id: int
     name: str
     description: str | None
-    example_file: str | None
+    example_files: list[str] = []
     created_at: datetime
     updated_at: datetime
     fields: list[FieldResponse] = []

--- a/backend/app/services/field_suggester.py
+++ b/backend/app/services/field_suggester.py
@@ -45,6 +45,43 @@ Use snake_case for field_name and descriptive labels for field_label.
 Field names should be in English."""
 
 
+MULTI_DOC_SYSTEM_PROMPT = """You are a document analysis assistant.
+You are given text extracted from MULTIPLE example documents of the same type.
+Your job is to:
+1. Analyze ALL documents to identify every extractable field across all examples.
+2. Compare the documents and note structural differences (e.g., fields that appear in some documents but not others).
+3. Suggest a unified set of fields that covers ALL the document variations.
+4. Mark fields that appear in ALL documents as "required": true.
+5. Mark fields that appear in ONLY SOME documents as "required": false.
+
+Return ONLY valid JSON with no additional text.
+
+Return:
+{
+  "fields": [
+    {
+      "field_name": "snake_case_name",
+      "field_label": "Human Readable Label",
+      "field_type": "text",
+      "required": true
+    }
+  ],
+  "analysis": {
+    "total_documents": 2,
+    "differences": ["Document 2 has an additional 'discount' field", "Document 1 uses 'client_name' while Document 2 uses 'customer_name' — unified as 'client_name'"]
+  }
+}
+
+Available field_type values: text, number, date, currency, boolean, table
+
+When documents contain tabular data, suggest a field with field_type "table" and include a "columns" array.
+Each column object has: name (snake_case), label (human-readable), type (text/number/date/currency/boolean).
+
+Suggest between 3 and 20 fields (more documents may reveal more fields).
+Use snake_case for field_name and descriptive labels for field_label.
+Field names should be in English."""
+
+
 VALID_TYPES = {"text", "number", "date", "currency", "boolean", "table"}
 VALID_COLUMN_TYPES = {"text", "number", "date", "currency", "boolean"}
 
@@ -55,7 +92,7 @@ async def suggest_fields(
     template_id: int | None = None,
     template_name: str | None = None,
 ) -> list[dict]:
-    """Analyze document text and suggest extractable fields."""
+    """Analyze a single document text and suggest extractable fields."""
     provider = get_provider(db)
 
     user_prompt = f"""Analyze this document and suggest fields that can be extracted:
@@ -65,14 +102,50 @@ Document text:
 
     response_text, trace = await provider.complete(SUGGESTION_SYSTEM_PROMPT, user_prompt)
 
-    # Save trace
     save_trace(db, trace, "field_suggestion", template_id=template_id,
                entity_name=template_name)
 
     data = parse_ai_json_response(response_text)
     fields = data.get("fields", [])
 
-    # Validate and normalize
+    return _normalize_fields(fields)
+
+
+async def suggest_fields_multi(
+    db: Session,
+    ocr_texts: list[str],
+    template_id: int | None = None,
+    template_name: str | None = None,
+) -> list[dict]:
+    """Analyze multiple document texts, compare differences, and suggest unified fields."""
+    provider = get_provider(db)
+
+    # Build the user prompt with all documents
+    per_doc_limit = AI_TEXT_MAX_LENGTH // len(ocr_texts) if ocr_texts else AI_TEXT_MAX_LENGTH
+    doc_sections = []
+    for i, text in enumerate(ocr_texts, 1):
+        doc_sections.append(f"--- DOCUMENT {i} ---\n{text[:per_doc_limit]}")
+
+    all_docs_text = "\n\n".join(doc_sections)
+
+    user_prompt = f"""Analyze these {len(ocr_texts)} example documents of the same type.
+Identify all extractable fields across all documents and note any differences between them.
+
+{all_docs_text}"""
+
+    response_text, trace = await provider.complete(MULTI_DOC_SYSTEM_PROMPT, user_prompt)
+
+    save_trace(db, trace, "field_suggestion", template_id=template_id,
+               entity_name=template_name)
+
+    data = parse_ai_json_response(response_text)
+    fields = data.get("fields", [])
+
+    return _normalize_fields(fields)
+
+
+def _normalize_fields(fields: list) -> list[dict]:
+    """Validate and normalize field suggestions from AI."""
     result = []
     for i, f in enumerate(fields):
         if not isinstance(f, dict):

--- a/backend/app/services/pipeline.py
+++ b/backend/app/services/pipeline.py
@@ -10,7 +10,7 @@ from app.models import Template, TemplateField, Document, ExtractionResult
 from app.services.ocr import extract_text
 from app.services.ai_extractor import extract_fields
 from app.services.classifier import classify_document
-from app.services.field_suggester import suggest_fields
+from app.services.field_suggester import suggest_fields, suggest_fields_multi
 from app.config import settings as app_settings
 from app.core.file_utils import get_file_full_path
 
@@ -148,23 +148,51 @@ async def process_document(db: Session, document_id: int) -> None:
 
 
 async def suggest_fields_for_template(db: Session, template: Template) -> None:
-    """Run AI field suggestion on a template's example document."""
-    if not template.example_file:
-        raise ValueError("Template has no example file")
+    """Run AI field suggestion on a template's example documents.
 
-    file_path = get_file_full_path(template.example_file)
-    file_ext = template.example_file.rsplit(".", 1)[-1].lower()
-    file_type = "pdf" if file_ext == "pdf" else f"image/{file_ext}"
+    When multiple example files exist, all are OCR-processed and the AI
+    compares them to build a unified field set — marking fields present in
+    all documents as required and the rest as optional.
+    """
+    # Resolve example files (supports both legacy single-path and JSON array)
+    example_files: list[str] = []
+    if template.example_files:
+        try:
+            parsed = json.loads(template.example_files)
+            example_files = parsed if isinstance(parsed, list) else [parsed]
+        except (ValueError, TypeError):
+            example_files = [template.example_files]
+    elif template.example_file:
+        example_files = [template.example_file]
 
-    ocr_text, _ = extract_text(file_path, file_type)
+    if not example_files:
+        raise ValueError("Template has no example files")
 
-    if not ocr_text.strip():
-        raise ValueError("OCR produced no text from the example document")
+    # OCR each file
+    ocr_texts: list[str] = []
+    for ef in example_files:
+        file_path = get_file_full_path(ef)
+        file_ext = ef.rsplit(".", 1)[-1].lower()
+        file_type = "pdf" if file_ext == "pdf" else f"image/{file_ext}"
 
-    suggested = await suggest_fields(
-        db, ocr_text,
-        template_id=template.id, template_name=template.name,
-    )
+        text, _ = extract_text(file_path, file_type)
+        if text.strip():
+            ocr_texts.append(text)
+
+    if not ocr_texts:
+        raise ValueError("OCR produced no text from the example documents")
+
+    # Use multi-doc or single-doc suggestion
+    if len(ocr_texts) > 1:
+        suggested = await suggest_fields_multi(
+            db, ocr_texts,
+            template_id=template.id, template_name=template.name,
+        )
+    else:
+        suggested = await suggest_fields(
+            db, ocr_texts[0],
+            template_id=template.id, template_name=template.name,
+        )
 
     # Clear existing fields and add new ones
     db.query(TemplateField).filter(TemplateField.template_id == template.id).delete()

--- a/backend/migrations/versions/d5e7a1f04c3b_rename_example_file_to_example_files.py
+++ b/backend/migrations/versions/d5e7a1f04c3b_rename_example_file_to_example_files.py
@@ -1,0 +1,55 @@
+"""rename example_file to example_files
+
+Revision ID: d5e7a1f04c3b
+Revises: c4a1e8f93b2d
+Create Date: 2026-03-27 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd5e7a1f04c3b'
+down_revision: Union[str, None] = 'c4a1e8f93b2d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # SQLite doesn't support ALTER COLUMN RENAME natively, so we use batch mode
+    with op.batch_alter_table('templates', schema=None) as batch_op:
+        batch_op.alter_column('example_file', new_column_name='example_files', type_=sa.Text())
+
+    # Migrate existing single-path values to JSON arrays
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, example_files FROM templates WHERE example_files IS NOT NULL")).fetchall()
+    for row in rows:
+        val = row[1]
+        # Skip if already a JSON array
+        if val and not val.startswith("["):
+            conn.execute(
+                sa.text("UPDATE templates SET example_files = :files WHERE id = :id"),
+                {"files": json.dumps([val]), "id": row[0]},
+            )
+
+
+def downgrade() -> None:
+    # Convert JSON arrays back to single paths
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, example_files FROM templates WHERE example_files IS NOT NULL")).fetchall()
+    for row in rows:
+        val = row[1]
+        if val and val.startswith("["):
+            files = json.loads(val)
+            single = files[0] if files else None
+            conn.execute(
+                sa.text("UPDATE templates SET example_files = :file WHERE id = :id"),
+                {"file": single, "id": row[0]},
+            )
+
+    with op.batch_alter_table('templates', schema=None) as batch_op:
+        batch_op.alter_column('example_files', new_column_name='example_file', type_=sa.String(500))

--- a/frontend/src/app/templates/[id]/page.tsx
+++ b/frontend/src/app/templates/[id]/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useState, useCallback } from "react";
+import { useParams } from "next/navigation";
+import { useDropzone } from "react-dropzone";
 import {
   useTemplate,
   useSuggestFields,
   useAddField,
   useDeleteField,
   useUpdateField,
+  useAddExampleFiles,
+  useRemoveExampleFile,
 } from "@/hooks/use-templates";
 import {
   Card,
@@ -37,6 +40,8 @@ import {
   Wand2,
   FileText,
   Table2,
+  Upload,
+  X,
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -72,11 +77,40 @@ export default function TemplateDetailPage() {
   const addFieldMutation = useAddField();
   const deleteFieldMutation = useDeleteField();
   const updateFieldMutation = useUpdateField();
+  const addFilesMutation = useAddExampleFiles();
+  const removeFileMutation = useRemoveExampleFile();
 
   const [newFieldName, setNewFieldName] = useState("");
   const [newFieldLabel, setNewFieldLabel] = useState("");
   const [newFieldType, setNewFieldType] = useState("text");
   const [newFieldColumns, setNewFieldColumns] = useState<NewColumn[]>([]);
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      if (!acceptedFiles.length) return;
+      const formData = new FormData();
+      acceptedFiles.forEach((f) => formData.append("files", f));
+      addFilesMutation.mutate(
+        { templateId: id, formData },
+        {
+          onSuccess: () =>
+            toast.success(
+              `${acceptedFiles.length} file${acceptedFiles.length > 1 ? "s" : ""} added`
+            ),
+          onError: () => toast.error("Failed to add files"),
+        }
+      );
+    },
+    [id, addFilesMutation]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "application/pdf": [".pdf"],
+      "image/*": [".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".webp"],
+    },
+  });
 
   const handleAddField = () => {
     if (!newFieldName.trim() || !newFieldLabel.trim()) {
@@ -87,7 +121,6 @@ export default function TemplateDetailPage() {
       toast.error("Table fields require at least one column");
       return;
     }
-    // Validate column names
     if (newFieldType === "table") {
       const emptyCol = newFieldColumns.find((c) => !c.name.trim() || !c.label.trim());
       if (emptyCol) {
@@ -138,6 +171,16 @@ export default function TemplateDetailPage() {
     });
   };
 
+  const handleRemoveFile = (index: number) => {
+    removeFileMutation.mutate(
+      { templateId: id, fileIndex: index },
+      {
+        onSuccess: () => toast.success("File removed"),
+        onError: () => toast.error("Failed to remove file"),
+      }
+    );
+  };
+
   const handleAddColumn = () => {
     setNewFieldColumns([...newFieldColumns, { name: "", label: "", type: "text" }]);
   };
@@ -165,6 +208,8 @@ export default function TemplateDetailPage() {
     return <p>Template not found</p>;
   }
 
+  const exampleFiles = template.example_files || [];
+
   return (
     <div className="space-y-8">
       <PageHeader
@@ -181,7 +226,7 @@ export default function TemplateDetailPage() {
               <FileText className="mr-1 h-3 w-3" />
               {template.document_count} documents
             </Badge>
-            {template.example_file && (
+            {exampleFiles.length > 0 && (
               <Button
                 variant="outline"
                 className="rounded-xl"
@@ -199,6 +244,69 @@ export default function TemplateDetailPage() {
           </div>
         }
       />
+
+      {/* Example Documents */}
+      <Card className="synapse-shadow border-border/50 rounded-2xl">
+        <CardHeader>
+          <CardTitle>Example Documents</CardTitle>
+          <CardDescription>
+            {exampleFiles.length > 1
+              ? `${exampleFiles.length} example documents — AI compares all to detect field differences`
+              : "Upload example documents for AI field suggestion"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {exampleFiles.length > 0 && (
+            <div className="space-y-2">
+              {exampleFiles.map((filePath, idx) => {
+                const fileName = filePath.split("/").pop() || filePath;
+                return (
+                  <div
+                    key={`${filePath}-${idx}`}
+                    className="flex items-center gap-3 rounded-lg border bg-muted/30 px-3 py-2"
+                  >
+                    <FileText className="h-4 w-4 shrink-0 text-green-600" />
+                    <span className="flex-1 text-sm font-medium truncate">
+                      {fileName}
+                    </span>
+                    <Badge variant="secondary" className="rounded-full text-xs">
+                      Doc {idx + 1}
+                    </Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 rounded-xl"
+                      onClick={() => handleRemoveFile(idx)}
+                      disabled={removeFileMutation.isPending}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <div
+            {...getRootProps()}
+            className={`flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed p-6 transition-colors ${
+              isDragActive
+                ? "border-primary bg-primary/5"
+                : "border-muted-foreground/25 hover:border-primary/50"
+            }`}
+          >
+            <input {...getInputProps()} />
+            {addFilesMutation.isPending ? (
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            ) : (
+              <Upload className="h-6 w-6 text-muted-foreground" />
+            )}
+            <p className="text-sm text-muted-foreground">
+              Drop files here to add more examples
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Fields */}
       <Card className="synapse-shadow border-border/50 rounded-2xl">

--- a/frontend/src/app/templates/new/page.tsx
+++ b/frontend/src/app/templates/new/page.tsx
@@ -16,7 +16,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
-import { Upload, FileText, Loader2, ArrowLeft } from "lucide-react";
+import { Upload, FileText, Loader2, ArrowLeft, X } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 
@@ -25,10 +25,10 @@ export default function NewTemplatePage() {
   const createMutation = useCreateTemplate();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [file, setFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
-    if (acceptedFiles.length > 0) setFile(acceptedFiles[0]);
+    setFiles((prev) => [...prev, ...acceptedFiles]);
   }, []);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -37,8 +37,11 @@ export default function NewTemplatePage() {
       "application/pdf": [".pdf"],
       "image/*": [".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".webp"],
     },
-    maxFiles: 1,
   });
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,11 +53,15 @@ export default function NewTemplatePage() {
     const formData = new FormData();
     formData.append("name", name.trim());
     if (description) formData.append("description", description);
-    if (file) formData.append("file", file);
+    files.forEach((file) => formData.append("files", file));
 
     createMutation.mutate(formData, {
       onSuccess: (data) => {
-        toast.success("Template created! AI is analyzing the document...");
+        const msg =
+          files.length > 1
+            ? `Template created! AI is analyzing ${files.length} documents...`
+            : "Template created! AI is analyzing the document...";
+        toast.success(msg);
         router.push(`/templates/${data.id}`);
       },
       onError: (err: any) => {
@@ -69,7 +76,7 @@ export default function NewTemplatePage() {
     <div className="mx-auto max-w-2xl space-y-8">
       <PageHeader
         title="New Template"
-        description="Upload an example document to auto-detect extractable fields"
+        description="Upload example documents to auto-detect extractable fields"
         actions={
           <Link href="/templates">
             <Button variant="ghost" size="icon" className="rounded-xl">
@@ -110,60 +117,67 @@ export default function NewTemplatePage() {
 
         <Card className="synapse-shadow border-border/50 rounded-2xl">
           <CardHeader>
-            <CardTitle>Example Document</CardTitle>
+            <CardTitle>Example Documents</CardTitle>
             <CardDescription>
-              Upload an example document. AI will analyze it and suggest
-              extractable fields.
+              Upload one or more example documents. When multiple files are
+              provided, AI will analyze all of them and compare differences to
+              build a comprehensive field set.
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <div
               {...getRootProps()}
               className={`flex cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors ${
                 isDragActive
                   ? "border-primary bg-primary/5"
-                  : file
-                    ? "border-green-500 bg-green-50"
-                    : "border-muted-foreground/25 hover:border-primary/50"
+                  : "border-muted-foreground/25 hover:border-primary/50"
               }`}
             >
               <input {...getInputProps()} />
-              {file ? (
-                <>
-                  <FileText className="h-10 w-10 text-green-600" />
-                  <div className="text-center">
-                    <p className="font-medium">{file.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {(file.size / 1024 / 1024).toFixed(2)} MB
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="rounded-xl"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setFile(null);
-                    }}
-                  >
-                    Remove
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <Upload className="h-10 w-10 text-muted-foreground" />
-                  <div className="text-center">
-                    <p className="font-medium">
-                      Drop your document here or click to browse
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      PDF, PNG, JPG, TIFF (max 50MB)
-                    </p>
-                  </div>
-                </>
-              )}
+              <Upload className="h-10 w-10 text-muted-foreground" />
+              <div className="text-center">
+                <p className="font-medium">
+                  Drop your documents here or click to browse
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  PDF, PNG, JPG, TIFF (max 50MB each) — multiple files allowed
+                </p>
+              </div>
             </div>
+
+            {files.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {files.length} file{files.length > 1 ? "s" : ""} selected
+                </p>
+                {files.map((file, idx) => (
+                  <div
+                    key={`${file.name}-${idx}`}
+                    className="flex items-center gap-3 rounded-lg border bg-muted/30 px-3 py-2"
+                  >
+                    <FileText className="h-4 w-4 shrink-0 text-green-600" />
+                    <span className="flex-1 text-sm font-medium truncate">
+                      {file.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {(file.size / 1024 / 1024).toFixed(2)} MB
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 rounded-xl"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removeFile(idx);
+                      }}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/frontend/src/hooks/use-templates.ts
+++ b/frontend/src/hooks/use-templates.ts
@@ -149,3 +149,45 @@ export function useDeleteField() {
       qc.invalidateQueries({ queryKey: ["template", vars.templateId] }),
   });
 }
+
+export function useAddExampleFiles() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      templateId,
+      formData,
+    }: {
+      templateId: number;
+      formData: FormData;
+    }) => {
+      const { data } = await api.post(
+        `/api/templates/${templateId}/example-files`,
+        formData,
+        { headers: { "Content-Type": "multipart/form-data" } }
+      );
+      return data as Template;
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ["template", vars.templateId] }),
+  });
+}
+
+export function useRemoveExampleFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      templateId,
+      fileIndex,
+    }: {
+      templateId: number;
+      fileIndex: number;
+    }) => {
+      const { data } = await api.delete(
+        `/api/templates/${templateId}/example-files/${fileIndex}`
+      );
+      return data as Template;
+    },
+    onSuccess: (_, vars) =>
+      qc.invalidateQueries({ queryKey: ["template", vars.templateId] }),
+  });
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,7 +19,7 @@ export interface Template {
   id: number;
   name: string;
   description: string | null;
-  example_file: string | null;
+  example_files: string[];
   created_at: string;
   updated_at: string;
   fields: TemplateField[];


### PR DESCRIPTION
## Summary
- Allow uploading **multiple example documents** when creating a template
- When multiple files are provided, AI processes all of them and **compares differences** to build a unified field set
- Fields present in **all documents** are marked as `required`, fields in only some are marked `optional`
- Template detail page shows list of example files with ability to add/remove individual files
- New API endpoints: `POST /api/templates/{id}/example-files` and `DELETE /api/templates/{id}/example-files/{index}`
- DB migration renames `example_file` (single path) to `example_files` (JSON array) with backward-compatible data conversion

## Test plan
- [ ] Create a template with a single file — verify field suggestion works as before
- [ ] Create a template with 2+ different example documents — verify AI analyzes all and suggests unified fields
- [ ] On template detail page, add more example files via drag-and-drop
- [ ] Remove individual example files from the list
- [ ] Click "Re-suggest Fields" with multiple files — verify multi-doc analysis runs
- [ ] Verify existing templates with legacy single-file data still work after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)