### PR TITLE
Auto-refresh document detail page while processing

### DIFF
--- a/frontend/src/hooks/use-documents.ts
+++ b/frontend/src/hooks/use-documents.ts
@@ -21,6 +21,8 @@ export function useDocuments(params?: {
   });
 }
 
+const PROCESSING_STATUSES = ["ocr_processing", "classifying", "extracting", "uploaded"];
+
 export function useDocument(id: number | null) {
   return useQuery<DocumentDetail>({
     queryKey: ["document", id],
@@ -29,6 +31,14 @@ export function useDocument(id: number | null) {
       return data;
     },
     enabled: !!id,
+    // Poll every 2s while the document is still being processed
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status && PROCESSING_STATUSES.includes(status)) {
+        return 2000;
+      }
+      return false;
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- Add conditional polling (every 2s) to `useDocument()` hook while document is in a processing state
- Polling stops automatically once status changes to `completed`, `failed`, or `review`
- Fixes the issue where preview and extracted fields only appeared after navigating away and back

## Test plan
- [ ] Upload a document and stay on the detail page — status updates automatically as it processes
- [ ] Once processing completes, extracted fields and preview appear without manual refresh
- [ ] After completion, polling stops (no unnecessary network requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)