### PR TITLE
Fix document preview and add download button

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -139,7 +139,12 @@ def delete_document(doc_id: int, db: Session = Depends(get_db)):
 
 
 @router.get("/{doc_id}/file")
-def serve_file(doc_id: int, db: Session = Depends(get_db)):
+def serve_file(doc_id: int, download: bool = False, db: Session = Depends(get_db)):
+    """Serve the document file.
+
+    By default the file is served inline (for preview in iframe/img).
+    Pass ?download=true to trigger a browser download instead.
+    """
     doc = db.query(Document).filter(Document.id == doc_id).first()
     if not doc:
         raise HTTPException(404, "Document not found")
@@ -148,7 +153,18 @@ def serve_file(doc_id: int, db: Session = Depends(get_db)):
         raise HTTPException(404, "File not found on disk")
 
     media_type = "application/pdf" if doc.file_type == "pdf" else f"image/{doc.file_type.split('/')[-1]}"
-    return FileResponse(path, media_type=media_type, filename=doc.filename)
+
+    if download:
+        return FileResponse(path, media_type=media_type, filename=doc.filename)
+
+    # Inline: serve without Content-Disposition attachment so browsers preview it
+    from starlette.responses import Response
+    content = path.read_bytes()
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Content-Disposition": f"inline; filename=\"{doc.filename}\""},
+    )
 
 
 @router.put("/{doc_id}/assign-template", response_model=DocumentResponse)

--- a/frontend/src/app/documents/[id]/page.tsx
+++ b/frontend/src/app/documents/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   Info,
   Plus,
   Trash2,
+  Download,
 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -285,6 +286,15 @@ export default function DocumentDetailPage() {
                     {(doc.file_size / 1024).toFixed(0)} KB
                   </span>
                 )}
+                <a
+                  href={`${fileUrl}?download=true`}
+                  download
+                >
+                  <Button variant="outline" className="rounded-xl">
+                    <Download className="mr-2 h-4 w-4" />
+                    Download
+                  </Button>
+                </a>
                 <Button
                   variant="outline"
                   className="rounded-xl"


### PR DESCRIPTION
## Summary
- **Fix preview**: File endpoint now serves files inline by default (`Content-Disposition: inline`) so PDFs render in iframes and images display in `<img>` tags
- **No auto-download**: Removed the unintended auto-download behavior on page load
- **Download button**: Added explicit "Download" button in the document header that uses `?download=true` to trigger the browser download

## Test plan
- [ ] Open a PDF document detail page — PDF renders in the preview iframe
- [ ] Open an image document — image renders in the preview area
- [ ] Click "Download" button — file downloads correctly
- [ ] Preview loads without triggering a download

🤖 Generated with [Claude Code](https://claude.com/claude-code)