### PR TITLE
Fix document preview for Unicode filenames

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -159,11 +159,13 @@ def serve_file(doc_id: int, download: bool = False, db: Session = Depends(get_db
 
     # Inline: serve without Content-Disposition attachment so browsers preview it
     from starlette.responses import Response
+    from urllib.parse import quote
+    safe_filename = quote(doc.filename)
     content = path.read_bytes()
     return Response(
         content=content,
         media_type=media_type,
-        headers={"Content-Disposition": f"inline; filename=\"{doc.filename}\""},
+        headers={"Content-Disposition": f"inline; filename*=UTF-8''{safe_filename}"},
     )
 
 


### PR DESCRIPTION
## Summary
- Fix 500 error when previewing documents with Unicode characters in filenames (ç, ã, etc.)
- Use RFC 5987 `filename*=UTF-8''` encoding in Content-Disposition header

## Test plan
- [ ] Open a document with accented characters in the filename — PDF preview renders
- [ ] Download button still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)